### PR TITLE
Update hyperlink to AWS Lambda docs

### DIFF
--- a/docs/03_app-configuration/02_server/README.md
+++ b/docs/03_app-configuration/02_server/README.md
@@ -20,7 +20,7 @@ Find more information on server integrations here:
 Name | Description
 ------------ | -------------
 [Webhook](./webhook.md './server/webhook') | Run an express server as HTTPS endpoint
-[AWS Lambda](./webhook.md './server/webhook') | Run the voice app as AWS Lambda Function
+[AWS Lambda](./aws-lambda.md './server/aws-lambda') | Run the voice app as AWS Lambda Function
 
 
 ## Code Example


### PR DESCRIPTION
## Proposed changes
Update hyperlink for the AWS Lambda link on the /docs/server page to link to /docs/server/aws-lambda, not /docs/server/webhook

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- You can also fill these out after creating the PR, or ask us, if you run into any problems! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed